### PR TITLE
support for 2025.1 IDE

### DIFF
--- a/pine-script-intellij-plugin/.gitignore
+++ b/pine-script-intellij-plugin/.gitignore
@@ -26,3 +26,6 @@ build/
 .Trashes
 ehthumbs.db
 Thumbs.db 
+
+# Ignore the .venv folder
+.venv

--- a/pine-script-intellij-plugin/build.gradle
+++ b/pine-script-intellij-plugin/build.gradle
@@ -23,14 +23,14 @@ task generateLexer(type: JavaExec) {
 }
 
 intellij {
-    version = '2023.3.4'
+    version = '2024.1'
     type = 'IC' // IntelliJ IDEA Community Edition
     plugins = ['com.intellij.java', 'org.jetbrains.plugins.textmate']
 }
 
 patchPluginXml {
     sinceBuild = '233'
-    untilBuild = '243.*'
+    untilBuild = '251.*'
     changeNotes = """
       <h3>0.1.0</h3>
       <ul>


### PR DESCRIPTION
- Added .venv folder to .gitignore to prevent virtual environment files from being tracked.
- Updated IntelliJ version from 2023.3.4 to 2024.1 in build.gradle.
- Adjusted untilBuild version from 243.* to 251.* to align with the new IntelliJ version.